### PR TITLE
Fix GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,11 @@ jobs:
         
       - name: Build
         run: npm run build
+
+      - name: Copy index.html for SPA routing
+        run: |
+          cp dist/index.html dist/404.html
+          touch dist/.nojekyll
         
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "homepage": "https://redberet.github.io/neon-grid-hacker/",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Redirecting...</title>
+    <meta http-equiv="refresh" content="0; url=/neon-grid-hacker/" />
+    <script>window.location.replace('/neon-grid-hacker/' + window.location.hash);
+    </script>
+  </head>
+  <body>
+    <p>Redirecting...</p>
+  </body>
+</html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
-  base: '/neon-grid-hacker/', // Set the base path for GitHub Pages
+  base: mode === 'production' ? '/neon-grid-hacker/' : '/',
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- add homepage url to package.json
- make vite base path conditional
- copy index.html for SPA routing in deploy workflow
- add 404 page redirect

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd1802ac883229943ef51fa12fb64