### PR TITLE
Ensure high score persists between games

### DIFF
--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -124,6 +124,7 @@ const gameReducer = (state: GameState, action: GameAction): GameState => {
         status: 'playing',
         difficulty: action.difficulty,
         grid: generateGrid(action.difficulty),
+        highScore: state.highScore,
         player: {
           ...initialState.player,
           x: 0,


### PR DESCRIPTION
## Summary
- keep previous `highScore` when dispatching the `START_GAME` action

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_683fdba24a4483228ab7ae92717c0441