### PR TITLE
Add tests for START_GAME reducer

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ In the project directory, you can run:
 - `npm run build` or `bun build`: Builds the app for production to the `dist` folder.
 - `npm run lint` or `bun lint`: Lints the project files using ESLint.
 - `npm run preview` or `bun preview`: Serves the production build locally for preview.
+- `npm test` or `bun test`: Runs the unit tests using Vitest.
 
 ## Deploying to GitHub Pages
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
+    "test": "vitest",
     "preview": "vite preview",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist"
@@ -84,6 +85,7 @@
     "gh-pages": "^6.0.0",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.19"
+    "vite": "^5.4.19",
+    "vitest": "^1.4.0"
   }
 }

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -50,7 +50,7 @@ type GameAction =
   | { type: 'RESET_IDLE_TIME' };
 
 // Initial state
-const initialState: GameState = {
+export const initialState: GameState = {
   status: 'idle',
   difficulty: 'easy',
   timeRemaining: 90, // 90 seconds
@@ -116,7 +116,7 @@ const generateGrid = (difficulty: Difficulty): Node[][] => {
 };
 
 // Reducer
-const gameReducer = (state: GameState, action: GameAction): GameState => {
+export const gameReducer = (state: GameState, action: GameAction): GameState => {
   switch (action.type) {
     case 'START_GAME':
       return {
@@ -129,6 +129,7 @@ const gameReducer = (state: GameState, action: GameAction): GameState => {
           x: 0,
           y: 0,
         },
+        highScore: state.highScore,
       };
       
     case 'PAUSE_GAME':

--- a/src/context/__tests__/gameReducer.test.ts
+++ b/src/context/__tests__/gameReducer.test.ts
@@ -1,0 +1,35 @@
+import { gameReducer, initialState, GameState } from '../GameContext';
+import { describe, it, expect } from 'vitest';
+
+describe('gameReducer START_GAME', () => {
+  it('preserves high score and resets other fields', () => {
+    const prevState: GameState = {
+      ...initialState,
+      status: 'gameOver',
+      highScore: 200,
+      score: 150,
+      timeRemaining: 30,
+      combo: 5,
+      idleTime: 10,
+      player: {
+        ...initialState.player,
+        x: 5,
+        y: 6,
+        integrity: 50,
+        canDash: false,
+        dashCooldown: 2,
+      },
+    };
+
+    const newState = gameReducer(prevState, { type: 'START_GAME', difficulty: 'hard' });
+
+    expect(newState.highScore).toBe(200);
+    expect(newState.status).toBe('playing');
+    expect(newState.difficulty).toBe('hard');
+    expect(newState.score).toBe(0);
+    expect(newState.combo).toBe(1);
+    expect(newState.timeRemaining).toBe(initialState.timeRemaining);
+    expect(newState.idleTime).toBe(0);
+    expect(newState.player).toEqual({ ...initialState.player, x: 0, y: 0 });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react-swc';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+  },
+});


### PR DESCRIPTION
## Summary
- add Vitest with config
- expose and fix `START_GAME` logic to keep high score
- create tests for `gameReducer`
- document `npm test` command

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fdba563e48322a376531571b74ebb